### PR TITLE
New feature - Reconciler

### DIFF
--- a/FluxQueue.BrokerHost/Program.cs
+++ b/FluxQueue.BrokerHost/Program.cs
@@ -18,6 +18,8 @@ builder.Services.AddSingleton(_ =>
 });
 
 // Background sweep: MVP needs it
+builder.Services.Configure<QueueReconcilerOptions>(builder.Configuration.GetSection("FluxQueue:Reconciler"));
+builder.Services.AddHostedService<QueueReconcilerHostedService>();
 builder.Services.Configure<QueueSweeperOptions>(builder.Configuration.GetSection("FluxQueue:Sweeper"));
 builder.Services.AddHostedService<QueueSweeper>();
 builder.Services.AddHealthChecks();

--- a/FluxQueue.BrokerHost/Services/QueueReconcilerHostedService.cs
+++ b/FluxQueue.BrokerHost/Services/QueueReconcilerHostedService.cs
@@ -1,0 +1,49 @@
+﻿using FluxQueue.Core;
+using Microsoft.Extensions.Options;
+
+namespace FluxQueue.BrokerHost.Services;
+public sealed class QueueReconcilerOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    // safest “option 2” that you chose: wipe old index CFs and rebuild from CF_MSG
+    public bool WipeAndRebuildIndexes { get; set; } = true;
+
+    public int MaxMessagesPerRun { get; set; } = 5_000_000; // safety cap
+    public int SweepBatchSize { get; set; } = 20_000;       // when expiring inflight during reconcile
+}
+public sealed class QueueReconcilerHostedService : IHostedService
+{
+    private readonly QueueEngine _engine;
+    private readonly IOptions<QueueReconcilerOptions> _opt;
+    private readonly ILogger<QueueReconcilerHostedService> _log;
+
+    public QueueReconcilerHostedService(
+        QueueEngine engine,
+        IOptions<QueueReconcilerOptions> opt,
+        ILogger<QueueReconcilerHostedService> log)
+    {
+        _engine = engine;
+        _opt = opt;
+        _log = log;
+    }
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        if (!_opt.Value.Enabled) return;
+
+        _log.LogWarning("FluxQueue reconciliation starting...");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        await _engine.ReconcileAsync(new ReconcileOptions
+        {
+            WipeAndRebuildIndexes = _opt.Value.WipeAndRebuildIndexes,
+            MaxMessages = _opt.Value.MaxMessagesPerRun,
+            SweepBatchSize = _opt.Value.SweepBatchSize
+        }, ct);
+
+        _log.LogWarning("FluxQueue reconciliation finished in {ElapsedMs}ms", sw.ElapsedMilliseconds);
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/FluxQueue.BrokerHost/Services/QueueSweeper.cs
+++ b/FluxQueue.BrokerHost/Services/QueueSweeper.cs
@@ -2,94 +2,61 @@
 using Microsoft.Extensions.Options;
 
 namespace FluxQueue.BrokerHost.Services;
-
 public sealed class QueueSweeper : BackgroundService
 {
     private readonly QueueEngine _engine;
-    private readonly QueueSweeperOptions _opt;
+    private readonly IOptions<QueueSweeperOptions> _opt;
     private readonly ILogger<QueueSweeper> _log;
 
-    // Simple per-queue backoff when sweep errors occur (avoid log spam)
-    private readonly Dictionary<string, DateTimeOffset> _skipUntil = [];
-
-    public QueueSweeper(
-        QueueEngine engine,
-        IOptions<QueueSweeperOptions> options,
-        ILogger<QueueSweeper> log)
+    public QueueSweeper(QueueEngine engine, IOptions<QueueSweeperOptions> opt, ILogger<QueueSweeper> log)
     {
         _engine = engine;
-        _opt = options.Value;
+        _opt = opt;
         _log = log;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _log.LogInformation("QueueSweeper started. SweepInterval={SweepInterval} IdleInterval={IdleInterval} MaxToProcessPerQueue={Max}",
-            _opt.SweepInterval, _opt.IdleInterval, _opt.MaxToProcessPerQueue);
+        if (!_opt.Value.Enabled) return;
 
         while (!stoppingToken.IsCancellationRequested)
         {
             var queues = _engine.KnownQueues;
-
             if (queues.Count == 0)
             {
-                await Task.Delay(_opt.IdleInterval, stoppingToken);
+                await Task.Delay(_opt.Value.IdleDelayMs, stoppingToken);
                 continue;
             }
 
-            var now = DateTimeOffset.UtcNow;
-            int totalProcessed = 0;
+            int anyProcessed = 0;
+            int swept = 0;
 
             foreach (var q in queues)
             {
-                stoppingToken.ThrowIfCancellationRequested();
-
-                // If a queue has been erroring, skip it briefly
-                if (_skipUntil.TryGetValue(q, out var until) && until > now)
-                    continue;
+                if (swept++ >= _opt.Value.MaxQueuesPerTick) break;
 
                 try
                 {
-                    var processed = await _engine.SweepExpiredAsync(
-                        queue: q,
-                        maxToProcess: _opt.MaxToProcessPerQueue,
-                        ct: stoppingToken);
-
-                    totalProcessed += processed;
-
-                    // Success: clear backoff
-                    _skipUntil.Remove(q);
+                    var p = await _engine.SweepExpiredAsync(q, _opt.Value.BatchSize, stoppingToken);
+                    anyProcessed += p;
                 }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
+                catch (OperationCanceledException) { throw; }
                 catch (Exception ex)
                 {
-                    // Back off this queue for a bit to avoid tight failure loops
-                    var backoff = TimeSpan.FromSeconds(5);
-                    _skipUntil[q] = now.Add(backoff);
-
-                    _log.LogWarning(ex, "Sweep failed for queue {Queue}. Backing off for {BackoffSeconds}s", q, backoff.TotalSeconds);
+                    _log.LogWarning(ex, "Sweeper failed for queue {Queue}", q);
                 }
             }
 
-            // If we did actual work, loop soon (keeps redelivery snappy).
-            // If we did no work, pause (reduces CPU churn).
-            var delay = totalProcessed > 0 ? _opt.SweepInterval : _opt.IdleInterval;
-            await Task.Delay(delay, stoppingToken);
+            await Task.Delay(anyProcessed > 0 ? _opt.Value.BusyDelayMs : _opt.Value.IdleDelayMs, stoppingToken);
         }
     }
 }
 
 public sealed class QueueSweeperOptions
 {
-    /// <summary>How often to run a full sweep cycle.</summary>
-    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromSeconds(1);
-
-    /// <summary>When there are no known queues, wait this long before checking again.</summary>
-    public TimeSpan IdleInterval { get; set; } = TimeSpan.FromSeconds(2);
-
-    /// <summary>Max inflight entries to process per queue per sweep cycle.</summary>
-    public int MaxToProcessPerQueue { get; set; } = 1000;
+    public bool Enabled { get; set; } = true;
+    public int BatchSize { get; set; } = 2000;
+    public int MaxQueuesPerTick { get; set; } = 50;
+    public int IdleDelayMs { get; set; } = 250;
+    public int BusyDelayMs { get; set; } = 10;
 }

--- a/FluxQueue.Core.Test/QueueEngineHardeningTests.cs
+++ b/FluxQueue.Core.Test/QueueEngineHardeningTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -779,15 +778,5 @@ public class QueueEngineHardeningTests
         }
 
         return count;
-    }
-}
-
-internal static class ReflectionExtensions
-{
-    public static T GetPrivateField<T>(this object obj, string fieldName)
-    {
-        var f = obj.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-        if (f is null) throw new InvalidOperationException($"Field not found: {fieldName}");
-        return (T)f.GetValue(obj)!;
     }
 }

--- a/FluxQueue.Core.Test/QueueEngineReconcileTests.cs
+++ b/FluxQueue.Core.Test/QueueEngineReconcileTests.cs
@@ -1,0 +1,354 @@
+﻿using FluxQueue.Tests;
+using NUnit.Framework.Legacy;
+using RocksDbSharp;
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Text;
+
+namespace FluxQueue.Core.Test;
+
+[TestFixture]
+public class QueueEngineReconcileTests
+{
+    private string _dir = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "fluxqueue-tests", "reconcile", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* ignore */ }
+    }
+
+    [Test]
+    public async Task Reconcile_WipeTrue_Should_ClearIndexCFs_And_RebuildFromMsg()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "q1";
+        await engine.SendAsync(q, Encoding.UTF8.GetBytes("a"));
+        await engine.SendAsync(q, Encoding.UTF8.GetBytes("b"));
+
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfReady = engine.GetPrivateField<ColumnFamilyHandle>("_cfReady");
+        var cfInflight = engine.GetPrivateField<ColumnFamilyHandle>("_cfInflight");
+        var cfReceipt = engine.GetPrivateField<ColumnFamilyHandle>("_cfReceipt");
+
+        // Add junk keys to each CF to prove wipe happens
+        db.Put(Encoding.UTF8.GetBytes("junk-ready"), Array.Empty<byte>(), cfReady);
+        db.Put(Encoding.UTF8.GetBytes("junk-inflight"), Array.Empty<byte>(), cfInflight);
+        db.Put(Encoding.UTF8.GetBytes("junk-receipt"), Array.Empty<byte>(), cfReceipt);
+
+        Assert.That(CountAllKeys(db, cfReady), Is.GreaterThan(0));
+        Assert.That(CountAllKeys(db, cfInflight), Is.GreaterThan(0));
+        Assert.That(CountAllKeys(db, cfReceipt), Is.GreaterThan(0));
+
+        await engine.ReconcileAsync(new ReconcileOptions
+        {
+            WipeAndRebuildIndexes = true,
+            MaxMessages = 5_000_000,
+            SweepBatchSize = 1_000
+        });
+
+        // junk keys must be gone
+        Assert.That(KeyExists(db, cfReady, Encoding.UTF8.GetBytes("junk-ready")), Is.False);
+        Assert.That(KeyExists(db, cfInflight, Encoding.UTF8.GetBytes("junk-inflight")), Is.False);
+        Assert.That(KeyExists(db, cfReceipt, Encoding.UTF8.GetBytes("junk-receipt")), Is.False);
+
+        // and messages should still be receivable (indexes rebuilt)
+        var got = await engine.ReceiveAsync(q, maxMessages: 10, visibilityTimeoutSeconds: 30, waitSeconds: 0);
+        Assert.That(got.Count, Is.EqualTo(2));
+
+        // Cleanup
+        foreach (var m in got)
+            Assert.That(await engine.AckAsync(q, m.ReceiptHandle), Is.True);
+    }
+
+    [Test]
+    public async Task Reconcile_Should_RecreateReadyIndex_ForReadyMessages()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qready";
+        var id = await engine.SendAsync(q, Encoding.UTF8.GetBytes("x"));
+
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfReady = engine.GetPrivateField<ColumnFamilyHandle>("_cfReady");
+
+        // Delete READY CF entirely to simulate lost index
+        WipeCF(db, cfReady);
+
+        // Sanity: should not deliver because index is gone
+        var before = await engine.ReceiveAsync(q, 1, 30, 0);
+        Assert.That(before.Count, Is.EqualTo(0));
+
+        await engine.ReconcileAsync(new ReconcileOptions { WipeAndRebuildIndexes = false });
+
+        var after = await engine.ReceiveAsync(q, 1, 30, 0);
+        Assert.That(after.Count, Is.EqualTo(1));
+        Assert.That(after[0].MessageId, Is.EqualTo(id));
+
+        Assert.That(await engine.AckAsync(q, after[0].ReceiptHandle), Is.True);
+    }
+
+    [Test]
+    public async Task Reconcile_Should_RecreateInflightAndReceipt_ForUnexpiredInflightMessages()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qinflight";
+        await engine.SendAsync(q, Encoding.UTF8.GetBytes("x"));
+
+        // Put into inflight
+        var got = await engine.ReceiveAsync(q, 1, visibilityTimeoutSeconds: 30, waitSeconds: 0);
+        Assert.That(got.Count, Is.EqualTo(1));
+        var msgId = got[0].MessageId;
+        var receipt = got[0].ReceiptHandle;
+
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfInflight = engine.GetPrivateField<ColumnFamilyHandle>("_cfInflight");
+        var cfReceipt = engine.GetPrivateField<ColumnFamilyHandle>("_cfReceipt");
+
+        // Simulate index loss (wipe inflight & receipt CF)
+        WipeCF(db, cfInflight);
+        WipeCF(db, cfReceipt);
+
+        // Ack should fail (receipt missing)
+        Assert.That(await engine.AckAsync(q, receipt), Is.False);
+
+        // Reconcile should rebuild inflight + receipt because it's not expired yet
+        await engine.ReconcileAsync(new ReconcileOptions { WipeAndRebuildIndexes = false });
+
+        // Ack should work again (receipt rebuilt)
+        Assert.That(await engine.AckAsync(q, receipt), Is.True);
+
+        // Message removed => receive empty
+        var again = await engine.ReceiveAsync(q, 1, 30, 0);
+        Assert.That(again.Count, Is.EqualTo(0));
+        Assert.That(again, Is.Empty);
+    }
+
+    [Test]
+    public async Task Reconcile_Should_DeleteCorruptMsgEnvelopes_FromMsgCF()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfMsg = engine.GetPrivateField<ColumnFamilyHandle>("_cfMsg");
+
+        // Put a corrupt msg record in CF_MSG
+        var corruptKey = Encoding.UTF8.GetBytes("corrupt-key");
+        db.Put(corruptKey, new byte[] { 1, 2, 3 }, cfMsg);
+
+        await engine.ReconcileAsync(new ReconcileOptions { WipeAndRebuildIndexes = false, MaxMessages = 10_000 });
+
+        Assert.That(KeyExists(db, cfMsg, corruptKey), Is.False, "Corrupt msg should be deleted from CF_MSG.");
+    }
+
+    [Test]
+    public async Task Reconcile_Should_PopulateKnownQueues_FromMsgMeta()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        await engine.SendAsync("qa", Encoding.UTF8.GetBytes("a"));
+        await engine.SendAsync("qb", Encoding.UTF8.GetBytes("b"));
+
+        // If KnownQueues was empty (fresh engine), reconcile should register queues from msg meta.
+        await engine.ReconcileAsync(new ReconcileOptions { WipeAndRebuildIndexes = true });
+
+        CollectionAssert.IsSupersetOf(engine.KnownQueues, new[] { "qa", "qb" });
+    }
+
+    [Test]
+    public async Task Reconcile_Should_Respect_MaxMessages_Cap()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qcap";
+        for (int i = 0; i < 10; i++)
+            await engine.SendAsync(q, Encoding.UTF8.GetBytes(i.ToString()));
+
+        // Wipe READY so reconcile must rebuild it
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfReady = engine.GetPrivateField<ColumnFamilyHandle>("_cfReady");
+        WipeCF(db, cfReady);
+
+        await engine.ReconcileAsync(new ReconcileOptions
+        {
+            WipeAndRebuildIndexes = false,
+            MaxMessages = 3, // only rebuild from 3 msg records
+        });
+
+        // We expect only up to 3 messages to become receivable.
+        // (Others remain stuck because READY index wasn't rebuilt for them.)
+        var got = await engine.ReceiveAsync(q, maxMessages: 50, visibilityTimeoutSeconds: 30, waitSeconds: 0);
+        Assert.That(got.Count, Is.InRange(0, 3));
+
+        // cleanup any received
+        foreach (var m in got)
+            await engine.AckAsync(q, m.ReceiptHandle);
+    }
+
+    [Test]
+    public void Reconcile_Should_Honor_Cancellation()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qcancel";
+        // enough messages so reconcile has something to do
+        for (int i = 0; i < 5_000; i++)
+            engine.SendAsync(q, Encoding.UTF8.GetBytes("x")).GetAwaiter().GetResult();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await engine.ReconcileAsync(new ReconcileOptions
+            {
+                WipeAndRebuildIndexes = true,
+                MaxMessages = 5_000_000,
+                SweepBatchSize = 100
+            }, cts.Token);
+        });
+    }
+
+    [Test]
+    public async Task Reconcile_WipeTrue_Should_NotThrow_On_LegacyReadyKeysPresent()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qlegacy";
+        await engine.SendAsync(q, Encoding.UTF8.GetBytes("x"));
+
+        var db = engine.GetPrivateField<RocksDb>("_db");
+        var cfReady = engine.GetPrivateField<ColumnFamilyHandle>("_cfReady");
+
+        // Insert an OLD-format READY key (without seq) to simulate leftover from earlier version
+        // This should not matter because WipeAndRebuildIndexes=true wipes READY CF first.
+        var legacyKey = LegacyReadyKey_NoSeq(q, NowMs() - 1, Guid.NewGuid().ToString("N"));
+        db.Put(legacyKey, Array.Empty<byte>(), cfReady);
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            await engine.ReconcileAsync(new ReconcileOptions { WipeAndRebuildIndexes = true });
+        });
+    }
+
+    [Test]
+    public async Task Reconcile_WipeTrue_Should_RequeueExpiredInflight_AfterSweep()
+    {
+        using var engine = new QueueEngine(_dir);
+
+        var q = "qexpired";
+        await engine.SendAsync(q, Encoding.UTF8.GetBytes("x"));
+
+        var got = await engine.ReceiveAsync(q, 1, visibilityTimeoutSeconds: 1, waitSeconds: 0);
+        Assert.That(got.Count, Is.EqualTo(1));
+
+        await Task.Delay(TimeSpan.FromSeconds(3)); // let inflight expire
+
+        await engine.ReconcileAsync(new ReconcileOptions
+        {
+            WipeAndRebuildIndexes = true,
+            SweepBatchSize = 1000
+        });
+
+        // Backoff on redelivery is ~2.0–2.5s for receiveCount=1, so wait.
+        var again = await engine.ReceiveAsync(q, 1, visibilityTimeoutSeconds: 30, waitSeconds: 5);
+
+        Assert.That(again.Count, Is.EqualTo(1),
+            "Expected expired inflight to be swept and requeued after reconcile (may be delayed by backoff).");
+    }
+
+    // -------------------------
+    // Helpers
+    // -------------------------
+
+    private static long NowMs() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    private static bool KeyExists(RocksDb db, ColumnFamilyHandle cf, byte[] key)
+        => db.Get(key, cf) is not null;
+
+    private static int CountAllKeys(RocksDb db, ColumnFamilyHandle cf)
+    {
+        int n = 0;
+        using var it = db.NewIterator(cf);
+        it.SeekToFirst();
+        while (it.Valid())
+        {
+            n++;
+            it.Next();
+        }
+        return n;
+    }
+
+    private static void WipeCF(RocksDb db, ColumnFamilyHandle cf)
+    {
+        using var it = db.NewIterator(cf);
+        it.SeekToFirst();
+        var batch = new WriteBatch();
+        int i = 0;
+
+        while (it.Valid())
+        {
+            batch.Delete(it.Key(), cf);
+            it.Next();
+
+            if (++i % 10_000 == 0)
+            {
+                db.Write(batch);
+                batch.Clear();
+            }
+        }
+
+        if (batch.Count() > 0)
+            db.Write(batch);
+    }
+
+    // Builds a legacy ready key in the OLD format: header + visibleAt + guid (no seq)
+    // Only used to simulate "old keys exist on disk".
+    private static byte[] LegacyReadyKey_NoSeq(string queue, long visibleAtMs, string msgId)
+    {
+        var qb = Encoding.UTF8.GetBytes(queue);
+        var gid = Guid.ParseExact(msgId, "N");
+
+        // header(4+q) + visibleAt(8) + guid(16)
+        var key = new byte[4 + qb.Length + 8 + 16];
+        key[0] = 1; // KEYV
+        key[1] = (byte)'r';
+        BinaryPrimitives.WriteUInt16BigEndian(key.AsSpan(2, 2), (ushort)qb.Length);
+        qb.CopyTo(key.AsSpan(4));
+
+        int o = 4 + qb.Length;
+        BinaryPrimitives.WriteInt64BigEndian(key.AsSpan(o, 8), visibleAtMs); o += 8;
+        gid.TryWriteBytes(key.AsSpan(o, 16));
+        return key;
+    }
+
+    // These call your production helpers (recommended).
+    // If QueueEngineHelpers isn't accessible in tests, tell me where it lives and I’ll adjust.
+    private static byte[] ReadyPrefix(string queue)
+        => QueueEngineHelpers.ReadyPrefix(queue);
+
+    private static byte[] ReadyKey(string queue, long visibleAtMs, long enqueueSeq, string msgId)
+        => QueueEngineHelpers.ReadyKey(queue, visibleAtMs, enqueueSeq, msgId);
+
+    private static byte[] InflightPrefix(string queue)
+        => QueueEngineHelpers.InflightPrefix(queue);
+
+    private static byte[] InflightKey(string queue, long untilMs, string msgId)
+        => QueueEngineHelpers.InflightKey(queue, untilMs, msgId);
+
+    private static void DeleteAllReceiptsForQueue(RocksDb db, ColumnFamilyHandle cfReceipt, string queue)
+    {
+        // If your receipts are not prefix-structured, you can just wipe CF in tests instead.
+        // Here we wipe the whole CF in this test suite when needed.
+        WipeCF(db, cfReceipt);
+    }
+}

--- a/FluxQueue.Core.Test/ReflectionExtensions.cs
+++ b/FluxQueue.Core.Test/ReflectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+
+namespace FluxQueue.Tests;
+
+internal static class ReflectionExtensions
+{
+    internal static T GetPrivateField<T>(this object obj, string fieldName)
+    {
+        var f = obj.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        if (f is null) throw new InvalidOperationException($"Field not found: {fieldName}");
+        return (T)f.GetValue(obj)!;
+    }
+}

--- a/FluxQueue.Core/QueueEngine.cs
+++ b/FluxQueue.Core/QueueEngine.cs
@@ -12,7 +12,12 @@ using RocksDbSharp;
 using static RocksDbSharp.ColumnFamilies;
 
 namespace FluxQueue.Core;
-
+public sealed class ReconcileOptions
+{
+    public bool WipeAndRebuildIndexes { get; set; } = true;
+    public int MaxMessages { get; set; } = 5_000_000;
+    public int SweepBatchSize { get; set; } = 20_000;
+}
 public class QueueEngine : IDisposable
 {
     // Column families
@@ -244,7 +249,12 @@ public class QueueEngine : IDisposable
             // Only process truly expired + consistent inflight records
             if (msg.State != MessageState.Inflight) { _db.Remove(inflightKeyBytes, _cfInflight); processed++; continue; }
             if (msg.InflightUntilMs != untilFromKey) { _db.Remove(inflightKeyBytes, _cfInflight); processed++; continue; }
-            if (msg.InflightUntilMs > nowMs) { processed++; continue; }
+            if (msg.InflightUntilMs > nowMs)
+            {
+                _db.Remove(inflightKeyBytes, _cfInflight);
+                processed++;
+                continue;
+            }
 
             // We need payload only if we will requeue or DLQ.
             ReadOnlyMemory<byte> payloadMem;
@@ -290,7 +300,7 @@ public class QueueEngine : IDisposable
             }
             else
             {
-                var delayMs = ComputeBackoffMs(msg.ReceiveCount);
+                var delayMs = QueueEngineHelpers.ComputeBackoffMs(msg.ReceiveCount);
                 var visibleAt = nowMs + delayMs;
 
                 msg.State = MessageState.Ready;
@@ -498,19 +508,6 @@ public class QueueEngine : IDisposable
 
     private static long NowMs() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-    private static long ComputeBackoffMs(int receiveCount)
-    {
-        var exp = Math.Min(6, Math.Max(0, receiveCount));
-        var baseMs = (long)(1000 * Math.Pow(2, exp));
-        baseMs = Math.Min(baseMs, 60_000);
-
-        Span<byte> b = stackalloc byte[2];
-        RandomNumberGenerator.Fill(b);
-        var jitter = BinaryPrimitives.ReadUInt16LittleEndian(b) % 500;
-
-        return baseMs + jitter;
-    }
-
     private void Signal(string queue)
     {
         if (_queueActors.TryGetValue(queue, out var actor))
@@ -605,6 +602,133 @@ public class QueueEngine : IDisposable
         {
             actor.Dispose();
         }
+    }
+
+    public async Task ReconcileAsync(ReconcileOptions opt, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (opt.WipeAndRebuildIndexes)
+        {
+            WipeColumnFamily(_cfReady, ct);
+            WipeColumnFamily(_cfInflight, ct);
+            WipeColumnFamily(_cfReceipt, ct);
+        }
+
+        // First pass: rebuild indexes from msg CF
+        var nowMs = NowMs();
+        int scanned = 0;
+
+        using var it = _db.NewIterator(_cfMsg);
+        it.SeekToFirst();
+
+        using var wb = new WriteBatch();
+
+        while (it.Valid() && scanned < opt.MaxMessages)
+        {
+            ct.ThrowIfCancellationRequested();
+            scanned++;
+
+            var msgKey = it.Key();     // byte[]
+            var msgVal = it.Value();   // byte[]
+
+            MessageRecord meta;
+            try
+            {
+                meta = DeserializeEnvelopeMeta<MessageRecord>(msgVal);
+            }
+            catch
+            {
+                // Corrupt -> drop it (or keep, depending on your philosophy)
+                wb.Delete(msgKey, _cfMsg);
+                if (scanned % 10_000 == 0) { _db.Write(wb); wb.Clear(); }
+                it.Next();
+                continue;
+            }
+
+            // Make sure KnownQueues includes it
+            if (!string.IsNullOrWhiteSpace(meta.Queue))
+                RegisterQueue(meta.Queue);
+
+            if (meta.State == MessageState.Ready)
+            {
+                // Recreate READY index
+                var rk = QueueEngineHelpers.ReadyKey(meta.Queue, meta.VisibleAtMs, meta.EnqueueSeq, meta.MessageId);
+                wb.Put(rk, Array.Empty<byte>(), _cfReady);
+            }
+            else if (meta.State == MessageState.Inflight)
+            {
+                // IMPORTANT: always rebuild inflight index, even if already expired.
+                // SweepExpiredAsync discovers expired inflight ONLY by scanning cfInflight.
+                var ik = QueueEngineHelpers.InflightKey(meta.Queue, meta.InflightUntilMs, meta.MessageId);
+                wb.Put(ik, Array.Empty<byte>(), _cfInflight);
+
+                if (!string.IsNullOrEmpty(meta.CurrentReceiptHandle))
+                {
+                    var receiptKey = QueueEngineHelpers.ReceiptKey(meta.Queue, meta.CurrentReceiptHandle);
+                    wb.Put(receiptKey, Serialize(new ReceiptRecord
+                    {
+                        Queue = meta.Queue,
+                        ReceiptHandle = meta.CurrentReceiptHandle,
+                        MessageId = meta.MessageId,
+                        InflightUntilMs = meta.InflightUntilMs,
+                        IssuedAtMs = meta.UpdatedAtMs
+                    }), _cfReceipt);
+                }
+            }
+
+            if (scanned % 10_000 == 0)
+            {
+                _db.Write(wb);
+                wb.Clear();
+            }
+
+            it.Next();
+        }
+
+        if (wb.Count() > 0)
+            _db.Write(wb);
+
+        // Second pass: run a sweep for all known queues to expire already-expired inflight
+        // This ensures expired inflight gets requeued/DLQ’d on startup.
+        foreach (var q in KnownQueues)
+        {
+            ct.ThrowIfCancellationRequested();
+            // sweep may need multiple loops if there are tons of inflight
+            for (int i = 0; i < 100; i++)
+            {
+                var processed = await SweepExpiredAsync(q, opt.SweepBatchSize, ct);
+                if (processed == 0) break;
+            }
+        }
+    }
+
+    private void WipeColumnFamily(ColumnFamilyHandle cf, CancellationToken ct)
+    {
+        using var it = _db.NewIterator(cf);
+        it.SeekToFirst();
+
+        var wb = new WriteBatch();
+        int n = 0;
+
+        while (it.Valid())
+        {
+            ct.ThrowIfCancellationRequested();
+
+            wb.Delete(it.Key(), cf);
+            n++;
+
+            if (n % 50_000 == 0)
+            {
+                _db.Write(wb);
+                wb.Clear();
+            }
+
+            it.Next();
+        }
+
+        if (n % 50_000 != 0)
+            _db.Write(wb);
     }
 
     private sealed class QueueActor : IDisposable

--- a/FluxQueue.Core/QueueEngineHelpers.cs
+++ b/FluxQueue.Core/QueueEngineHelpers.cs
@@ -160,4 +160,17 @@ public static class QueueEngineHelpers
 
     public static void WriteInt64BE(Span<byte> dst, long value) =>
         BinaryPrimitives.WriteInt64BigEndian(dst, value);
+
+    public static long ComputeBackoffMs(int receiveCount)
+    {
+        var exp = Math.Min(6, Math.Max(0, receiveCount));
+        var baseMs = (long)(1000 * Math.Pow(2, exp));
+        baseMs = Math.Min(baseMs, 60_000);
+
+        Span<byte> b = stackalloc byte[2];
+        RandomNumberGenerator.Fill(b);
+        var jitter = BinaryPrimitives.ReadUInt16LittleEndian(b) % 500;
+
+        return baseMs + jitter;
+    }
 }


### PR DESCRIPTION
#### PR Classification  
New feature, code cleanup, and refactoring to improve maintainability, configurability, and robustness of queue management.  

#### PR Summary  
Introduced a new `QueueReconcilerHostedService`, refactored `QueueSweeper`, and centralized key helper methods to enhance modularity and functionality.  
- **`QueueEngine`**: Added `ReconcileAsync` for index rebuilding and expired message cleanup; removed inline key helper methods.  
- **`QueueEngineHelpers`**: Centralized key-related logic and backoff computation.  
- **`QueueSweeper`**: Refactored to use `QueueSweeperOptions` and simplified backoff logic.  
- **Unit Tests**: Added `QueueEngineReconcileTests` to validate reconciliation behavior.  
- **`Program.cs`**: Registered new services and updated configuration.  
